### PR TITLE
Dead-code cleanup, namespace-filter dedup, credential tests, and API-compat docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ env:
 
 This configuration watches only namespaces with label `managed-by=k8smultiarcher` while explicitly ignoring `dev-sandbox` and `test-temp`.
 
+## Kubernetes API Compatibility
+
+k8smultiarcher consumes **typed** `k8s.io/api` structs (e.g. `corev1.Pod`, `appsv1.DaemonSet`, `admissionv1.AdmissionReview`) rather than unstructured maps. This makes Kubernetes API-shape compatibility a **compile-time** property: if a future `k8s.io/*` release renames or removes a field the webhook reads, `go build` fails. Because Dependabot bumps `k8s.io/*` and CI runs `go build`, breaking API-shape changes surface automatically as a red check.
+
+Compilation cannot catch JSON serialization or defaulting drift (for example, a new admission API version or a changed default value). To guard that, a golden-file test (`admission_golden_test.go` together with `testdata/`) pins the webhook's `AdmissionReview` response wire shape. Intentional changes show up as an explicit, reviewable diff; regenerate the golden files with:
+
+```bash
+go test -run TestProcessAdmissionReview_Golden -update
+```
+
 ## Container Images
 
 Multi-architecture container images are available at `ghcr.io/programmerq/k8smultiarcher` supporting linux/amd64, linux/arm64, and linux/arm/v7 platforms.

--- a/admission.go
+++ b/admission.go
@@ -22,13 +22,6 @@ const (
 	AnnotationNamespaceDisabled = "k8smultiarcher.programmerq.io/disabled"
 )
 
-var MultiarchToleration = corev1.Toleration{
-	Key:      "k8smultiarcher",
-	Value:    "arm64Supported",
-	Operator: corev1.TolerationOpEqual,
-	Effect:   "NoSchedule",
-}
-
 // PodHasSkipAnnotation returns true if the pod has the skip-mutation annotation set to "true"
 func PodHasSkipAnnotation(pod *corev1.Pod) bool {
 	if pod.Annotations == nil {
@@ -43,6 +36,35 @@ func PodTemplateHasSkipAnnotation(template *corev1.PodTemplateSpec) bool {
 		return false
 	}
 	return template.Annotations[AnnotationSkipMutation] == "true"
+}
+
+// shouldSkipMutation reports whether mutation should be skipped for an object,
+// based on its skip-mutation annotation, the namespace filter config, and the
+// namespace's disabled annotation. The kind and name are used only for logging.
+func shouldSkipMutation(
+	ctx context.Context,
+	kind, name, namespace string,
+	hasSkipAnnotation bool,
+	namespaceFilterCfg *NamespaceFilterConfig,
+) bool {
+	if hasSkipAnnotation {
+		slog.Info("skipping mutation due to skip annotation", "kind", kind, "name", name, "namespace", namespace)
+		return true
+	}
+
+	// Check if namespace is filtered by namespace selector or ignore list
+	if namespace != "" && IsNamespaceFiltered(ctx, namespace, namespaceFilterCfg) {
+		slog.Info("skipping mutation due to namespace filter", "namespace", namespace)
+		return true
+	}
+
+	// Check if namespace has disabled annotation
+	if namespace != "" && IsNamespaceDisabled(ctx, namespace) {
+		slog.Info("skipping mutation due to namespace annotation", "namespace", namespace)
+		return true
+	}
+
+	return false
 }
 
 func ProcessAdmissionReview(
@@ -75,29 +97,13 @@ func ProcessAdmissionReview(
 			return nil, err
 		}
 
-		// Check if pod has skip annotation
-		if PodHasSkipAnnotation(pod) {
-			slog.Info("skipping mutation due to pod annotation", "pod", pod.Name, "namespace", pod.Namespace)
-			review.Response = &response
-			return review, nil
-		}
-
 		// Use review.Request.Namespace as it's the authoritative source, falling back to pod.Namespace
 		namespace := review.Request.Namespace
 		if namespace == "" {
 			namespace = pod.Namespace
 		}
 
-		// Check if namespace is filtered by namespace selector or ignore list
-		if namespace != "" && IsNamespaceFiltered(ctx, namespace, namespaceFilterCfg) {
-			slog.Info("skipping mutation due to namespace filter", "namespace", namespace)
-			review.Response = &response
-			return review, nil
-		}
-
-		// Check if namespace has disabled annotation
-		if namespace != "" && IsNamespaceDisabled(ctx, namespace) {
-			slog.Info("skipping mutation due to namespace annotation", "namespace", namespace)
+		if shouldSkipMutation(ctx, "Pod", pod.Name, namespace, PodHasSkipAnnotation(pod), namespaceFilterCfg) {
 			review.Response = &response
 			return review, nil
 		}
@@ -126,29 +132,16 @@ func ProcessAdmissionReview(
 			return nil, err
 		}
 
-		// Check if pod template has skip annotation
-		if PodTemplateHasSkipAnnotation(&daemonSet.Spec.Template) {
-			slog.Info("skipping mutation due to daemonset template annotation", "daemonset", daemonSet.Name, "namespace", daemonSet.Namespace)
-			review.Response = &response
-			return review, nil
-		}
-
 		// Use review.Request.Namespace as it's the authoritative source, falling back to daemonSet.Namespace
 		namespace := review.Request.Namespace
 		if namespace == "" {
 			namespace = daemonSet.Namespace
 		}
 
-		// Check if namespace is filtered by namespace selector or ignore list
-		if namespace != "" && IsNamespaceFiltered(ctx, namespace, namespaceFilterCfg) {
-			slog.Info("skipping mutation due to namespace filter", "namespace", namespace)
-			review.Response = &response
-			return review, nil
-		}
-
-		// Check if namespace has disabled annotation
-		if namespace != "" && IsNamespaceDisabled(ctx, namespace) {
-			slog.Info("skipping mutation due to namespace annotation", "namespace", namespace)
+		if shouldSkipMutation(
+			ctx, "DaemonSet", daemonSet.Name, namespace,
+			PodTemplateHasSkipAnnotation(&daemonSet.Spec.Template), namespaceFilterCfg,
+		) {
 			review.Response = &response
 			return review, nil
 		}
@@ -209,27 +202,6 @@ func AdmissionReviewFromRequest(body []byte) (*admissionv1.AdmissionReview, erro
 	}
 
 	return &review, nil
-}
-
-func DoesPodSupportArm64(ctx context.Context, cache Cache, pod *corev1.Pod, registryHosts []config.Host) bool {
-	var errs []error
-	for _, container := range pod.Spec.Containers {
-		if !DoesImageSupportArm64(ctx, cache, container.Image, registryHosts) {
-			errs = append(errs, fmt.Errorf("image %s lacks arm64 support", container.Image))
-		}
-	}
-	if len(errs) > 0 {
-		slog.Info("pod has images without arm64 support", "error", errors.Join(errs...))
-		return false
-	}
-	return true
-}
-
-func AddMultiarchTolerationToPod(pod *corev1.Pod) {
-	if slices.Contains(pod.Spec.Tolerations, MultiarchToleration) {
-		return
-	}
-	pod.Spec.Tolerations = append(pod.Spec.Tolerations, MultiarchToleration)
 }
 
 // GetPodSupportedPlatforms returns platforms supported by all images in the pod

--- a/admission_golden_test.go
+++ b/admission_golden_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// updateGolden regenerates the golden files instead of comparing against them.
+// Run: go test -run TestProcessAdmissionReview_Golden -update
+var updateGolden = flag.Bool("update", false, "update golden files in testdata/")
+
+const goldenImage = "nginx:latest"
+
+// goldenConfig is a fixed multi-platform config so the rendered response is deterministic.
+func goldenConfig() *PlatformTolerationConfig {
+	return &PlatformTolerationConfig{
+		Mappings: []PlatformTolerationMapping{
+			{
+				Platform: "linux/arm64",
+				Toleration: corev1.Toleration{
+					Key:      "arch",
+					Value:    "arm64",
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+			{
+				Platform: "linux/amd64",
+				Toleration: corev1.Toleration{
+					Key:      "arch",
+					Value:    "amd64",
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// canonicalResponse renders an AdmissionResponse into stable, human-readable JSON.
+// The JSON patch is decoded and its operations are sorted by their canonical
+// serialization, so non-deterministic patch-generation order cannot cause flaky
+// golden mismatches. What remains in the golden is the meaningful response shape:
+// allowed, patch type, and the set of patch operations.
+func canonicalResponse(t *testing.T, resp *admissionv1.AdmissionResponse) []byte {
+	t.Helper()
+
+	var patch []map[string]any
+	if len(resp.Patch) > 0 {
+		if err := json.Unmarshal(resp.Patch, &patch); err != nil {
+			t.Fatalf("unmarshal patch: %v", err)
+		}
+		// Sort by each op's canonical serialization so jsonpatch.CreatePatch's
+		// non-deterministic op order can't cause flaky golden mismatches. The op
+		// and its key are sorted together; keys are precomputed (with error
+		// handling) since a sort comparator can't fail.
+		type keyedOp struct {
+			op  map[string]any
+			key string
+		}
+		keyed := make([]keyedOp, len(patch))
+		for i, op := range patch {
+			b, err := json.Marshal(op)
+			if err != nil {
+				t.Fatalf("marshal patch op: %v", err)
+			}
+			keyed[i] = keyedOp{op: op, key: string(b)}
+		}
+		sort.SliceStable(keyed, func(i, j int) bool { return keyed[i].key < keyed[j].key })
+		for i := range keyed {
+			patch[i] = keyed[i].op
+		}
+	}
+
+	view := struct {
+		UID       string                 `json:"uid"`
+		Allowed   bool                   `json:"allowed"`
+		PatchType *admissionv1.PatchType `json:"patchType,omitempty"`
+		Patch     []map[string]any       `json:"patch,omitempty"`
+	}{
+		UID:       string(resp.UID),
+		Allowed:   resp.Allowed,
+		PatchType: resp.PatchType,
+		Patch:     patch,
+	}
+
+	out, err := json.MarshalIndent(view, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal canonical response: %v", err)
+	}
+	return append(out, '\n')
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// admissionReviewBytes wraps a raw object into an AdmissionReview request body.
+func admissionReviewBytes(t *testing.T, kind metav1.GroupVersionKind, raw []byte) []byte {
+	t.Helper()
+	review := &admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AdmissionReview",
+			APIVersion: "admission.k8s.io/v1",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:    "golden-uid",
+			Kind:   kind,
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	}
+	return mustMarshal(t, review)
+}
+
+func goldenPodBody(t *testing.T) []byte {
+	t.Helper()
+	pod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "golden-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers:  []corev1.Container{{Name: "nginx", Image: goldenImage}},
+			Tolerations: []corev1.Toleration{},
+		},
+	}
+	return admissionReviewBytes(t, metav1.GroupVersionKind{Version: "v1", Kind: "Pod"}, mustMarshal(t, pod))
+}
+
+func goldenDaemonSetBody(t *testing.T) []byte {
+	t.Helper()
+	ds := &appsv1.DaemonSet{
+		TypeMeta:   metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "golden-daemonset", Namespace: "default"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "golden"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "golden"}},
+				Spec: corev1.PodSpec{
+					Containers:  []corev1.Container{{Name: "nginx", Image: goldenImage}},
+					Tolerations: []corev1.Toleration{},
+				},
+			},
+		},
+	}
+	kind := metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
+	return admissionReviewBytes(t, kind, mustMarshal(t, ds))
+}
+
+// TestProcessAdmissionReview_Golden pins the webhook's AdmissionReview response
+// shape against checked-in golden files. It guards against k8s JSON
+// serialization / defaulting drift that the compiler cannot catch (a renamed or
+// removed struct field is a build failure; a changed wire shape is not).
+func TestProcessAdmissionReview_Golden(t *testing.T) {
+	cache := NewInMemoryCache(cacheSizeDefault)
+	cache.Set(goldenImage+":linux/arm64", true, 0)
+	cache.Set(goldenImage+":linux/amd64", true, 0)
+
+	cfg := goldenConfig()
+
+	tests := []struct {
+		name   string
+		golden string
+		body   []byte
+	}{
+		{"pod", "pod_response.json", goldenPodBody(t)},
+		{"daemonset", "daemonset_response.json", goldenDaemonSetBody(t)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ProcessAdmissionReview(context.Background(), cache, cfg, nil, tc.body)
+			if err != nil {
+				t.Fatalf("ProcessAdmissionReview failed: %v", err)
+			}
+			if result.Response == nil {
+				t.Fatal("Response is nil")
+			}
+
+			got := canonicalResponse(t, result.Response)
+			goldenPath := filepath.Join("testdata", tc.golden)
+
+			if *updateGolden {
+				if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("read golden (regenerate with `go test -run TestProcessAdmissionReview_Golden -update`): %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("response shape changed vs %s.\n--- got ---\n%s\nIf this change is intended, regenerate with "+
+					"`go test -run TestProcessAdmissionReview_Golden -update`.", goldenPath, got)
+			}
+		})
+	}
+}

--- a/admission_test.go
+++ b/admission_test.go
@@ -9,43 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAddMultiarchTolerationToPod(t *testing.T) {
-	pod := &corev1.Pod{
-		Spec: corev1.PodSpec{
-			Tolerations: []corev1.Toleration{
-				{
-					Key:      "key1",
-					Operator: corev1.TolerationOpEqual,
-					Value:    "value1",
-				},
-				{
-					Key:      "key2",
-					Operator: corev1.TolerationOpEqual,
-					Value:    "value2",
-				},
-			},
-		},
-	}
-	AddMultiarchTolerationToPod(pod)
-	expectedTolerations := []corev1.Toleration{
-		{
-			Key:      "key1",
-			Operator: corev1.TolerationOpEqual,
-			Value:    "value1",
-		},
-		{
-			Key:      "key2",
-			Operator: corev1.TolerationOpEqual,
-			Value:    "value2",
-		},
-		MultiarchToleration,
-	}
-
-	if !slices.Equal(pod.Spec.Tolerations, expectedTolerations) {
-		t.Errorf("Unexpected tolerations. Expected: %v, Got: %v", expectedTolerations, pod.Spec.Tolerations)
-	}
-}
-
 func TestGetPodSupportedPlatforms(t *testing.T) {
 	cache := NewInMemoryCache(cacheSizeDefault)
 	cache.Set("image1:linux/arm64", true, 0)

--- a/registry_auth_credentials_test.go
+++ b/registry_auth_credentials_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/regclient/regclient/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const credTestRegistry = "registry.example.com"
+
+// setKubeClient replaces the package-level kubeClient singleton with the given
+// fake clientset so credential-resolution paths can be exercised without a
+// live cluster.
+func setKubeClient(client *fake.Clientset) {
+	kubeClientOnce = sync.Once{}
+	kubeClientOnce.Do(func() {
+		kubeClient = client
+		kubeClientErr = nil
+	})
+}
+
+func b64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestDecodeDockerAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoded  string
+		wantUser string
+		wantPass string
+		wantErr  bool
+	}{
+		{name: "user and password", encoded: b64("alice:s3cret"), wantUser: "alice", wantPass: "s3cret"},
+		{name: "password containing colons", encoded: b64("alice:p:a:s:s"), wantUser: "alice", wantPass: "p:a:s:s"},
+		{name: "invalid base64", encoded: "!!!not-base64!!!", wantErr: true},
+		{name: "missing colon separator", encoded: b64("alicenopassword"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, pass, err := decodeDockerAuth(tt.encoded)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("decodeDockerAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if user != tt.wantUser || pass != tt.wantPass {
+				t.Errorf("decodeDockerAuth() = (%q, %q), want (%q, %q)", user, pass, tt.wantUser, tt.wantPass)
+			}
+		})
+	}
+}
+
+func TestHostsFromAuths(t *testing.T) {
+	tests := []struct {
+		name    string
+		auths   map[string]dockerAuthEntry
+		wantLen int
+		check   func(t *testing.T, host config.Host)
+	}{
+		{
+			name:    "username and password",
+			auths:   map[string]dockerAuthEntry{credTestRegistry: {Username: "alice", Password: "s3cret"}},
+			wantLen: 1,
+			check: func(t *testing.T, host config.Host) {
+				if host.User != "alice" || host.Pass != "s3cret" {
+					t.Errorf("got user=%q pass=%q", host.User, host.Pass)
+				}
+			},
+		},
+		{
+			name:    "auth field decoded into user and password",
+			auths:   map[string]dockerAuthEntry{credTestRegistry: {Auth: b64("bob:p:w:d")}},
+			wantLen: 1,
+			check: func(t *testing.T, host config.Host) {
+				if host.User != "bob" || host.Pass != "p:w:d" {
+					t.Errorf("got user=%q pass=%q", host.User, host.Pass)
+				}
+			},
+		},
+		{
+			name:    "identity token only",
+			auths:   map[string]dockerAuthEntry{credTestRegistry: {IdentityToken: "tok-123"}},
+			wantLen: 1,
+			check: func(t *testing.T, host config.Host) {
+				if host.Token != "tok-123" {
+					t.Errorf("got token=%q", host.Token)
+				}
+			},
+		},
+		{
+			name:    "empty entry is skipped",
+			auths:   map[string]dockerAuthEntry{credTestRegistry: {}},
+			wantLen: 0,
+		},
+		{
+			name:    "registry with a path fails validation and is skipped",
+			auths:   map[string]dockerAuthEntry{credTestRegistry + "/with/path": {Username: "alice", Password: "s3cret"}},
+			wantLen: 0,
+		},
+		{
+			name:    "undecodable auth is skipped",
+			auths:   map[string]dockerAuthEntry{credTestRegistry: {Auth: "!!!not-base64!!!"}},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hosts := hostsFromAuths(tt.auths)
+			if len(hosts) != tt.wantLen {
+				t.Fatalf("hostsFromAuths() returned %d hosts, want %d: %#v", len(hosts), tt.wantLen, hosts)
+			}
+			if tt.check != nil {
+				tt.check(t, hosts[0])
+			}
+		})
+	}
+}
+
+func TestHostsFromSecret(t *testing.T) {
+	dockerConfigJSONData, err := json.Marshal(dockerConfigJSON{
+		Auths: map[string]dockerAuthEntry{credTestRegistry: {Username: "alice", Password: "s3cret"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal dockerconfigjson: %v", err)
+	}
+	legacyDockercfgData, err := json.Marshal(map[string]dockerAuthEntry{
+		credTestRegistry: {Username: "bob", Password: "hunter2"},
+	})
+	if err != nil {
+		t.Fatalf("marshal dockercfg: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		secret   *corev1.Secret
+		wantLen  int
+		wantErr  bool
+		wantUser string
+	}{
+		{
+			name: "dockerconfigjson secret",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: dockerConfigJSONData},
+			},
+			wantLen:  1,
+			wantUser: "alice",
+		},
+		{
+			name: "legacy dockercfg secret",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeDockercfg,
+				Data: map[string][]byte{corev1.DockerConfigKey: legacyDockercfgData},
+			},
+			wantLen:  1,
+			wantUser: "bob",
+		},
+		{
+			name: "dockerconfigjson missing data",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dockercfg missing data",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeDockercfg,
+				Data: map[string][]byte{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed dockerconfigjson",
+			secret: &corev1.Secret{
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{corev1.DockerConfigJsonKey: []byte("{not json")},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported secret type",
+			secret:  &corev1.Secret{Type: corev1.SecretTypeOpaque},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hosts, err := hostsFromSecret(tt.secret)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("hostsFromSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(hosts) != tt.wantLen {
+				t.Fatalf("hostsFromSecret() returned %d hosts, want %d", len(hosts), tt.wantLen)
+			}
+			if tt.wantLen > 0 && hosts[0].User != tt.wantUser {
+				t.Errorf("hostsFromSecret() user = %q, want %q", hosts[0].User, tt.wantUser)
+			}
+		})
+	}
+}
+
+func TestGetRegistryHosts(t *testing.T) {
+	const ns = "team-a"
+
+	dockerCfg, err := json.Marshal(dockerConfigJSON{
+		Auths: map[string]dockerAuthEntry{credTestRegistry: {Username: "alice", Password: "s3cret"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal dockerconfigjson: %v", err)
+	}
+	pullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "regcred", Namespace: ns},
+		Type:       corev1.SecretTypeDockerConfigJson,
+		Data:       map[string][]byte{corev1.DockerConfigJsonKey: dockerCfg},
+	}
+
+	t.Run("empty namespace returns nil", func(t *testing.T) {
+		setKubeClient(fake.NewSimpleClientset())
+		if hosts := GetRegistryHosts(context.Background(), "", &corev1.PodSpec{}); hosts != nil {
+			t.Errorf("expected nil, got %#v", hosts)
+		}
+	})
+
+	t.Run("nil pod spec returns nil", func(t *testing.T) {
+		setKubeClient(fake.NewSimpleClientset())
+		if hosts := GetRegistryHosts(context.Background(), ns, nil); hosts != nil {
+			t.Errorf("expected nil, got %#v", hosts)
+		}
+	})
+
+	t.Run("no image pull secrets returns nil", func(t *testing.T) {
+		setKubeClient(fake.NewSimpleClientset())
+		if hosts := GetRegistryHosts(context.Background(), ns, &corev1.PodSpec{}); hosts != nil {
+			t.Errorf("expected nil, got %#v", hosts)
+		}
+	})
+
+	t.Run("pod image pull secret is resolved", func(t *testing.T) {
+		setKubeClient(fake.NewSimpleClientset(pullSecret))
+		podSpec := &corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}}}
+		hosts := GetRegistryHosts(context.Background(), ns, podSpec)
+		if len(hosts) != 1 || hosts[0].User != "alice" || hosts[0].Pass != "s3cret" {
+			t.Fatalf("unexpected hosts: %#v", hosts)
+		}
+	})
+
+	t.Run("service account image pull secret is resolved", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta:       metav1.ObjectMeta{Name: "default", Namespace: ns},
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}},
+		}
+		setKubeClient(fake.NewSimpleClientset(pullSecret, sa))
+		hosts := GetRegistryHosts(context.Background(), ns, &corev1.PodSpec{})
+		if len(hosts) != 1 || hosts[0].User != "alice" {
+			t.Fatalf("unexpected hosts: %#v", hosts)
+		}
+	})
+
+	t.Run("missing referenced secret yields empty non-nil slice", func(t *testing.T) {
+		setKubeClient(fake.NewSimpleClientset())
+		podSpec := &corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "nope"}}}
+		hosts := GetRegistryHosts(context.Background(), ns, podSpec)
+		if hosts == nil || len(hosts) != 0 {
+			t.Fatalf("expected empty non-nil slice, got %#v", hosts)
+		}
+	})
+}

--- a/testdata/daemonset_response.json
+++ b/testdata/daemonset_response.json
@@ -1,0 +1,25 @@
+{
+  "uid": "golden-uid",
+  "allowed": true,
+  "patchType": "JSONPatch",
+  "patch": [
+    {
+      "op": "add",
+      "path": "/spec/template/spec/tolerations",
+      "value": [
+        {
+          "effect": "NoSchedule",
+          "key": "arch",
+          "operator": "Equal",
+          "value": "arm64"
+        },
+        {
+          "effect": "NoSchedule",
+          "key": "arch",
+          "operator": "Equal",
+          "value": "amd64"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/pod_response.json
+++ b/testdata/pod_response.json
@@ -1,0 +1,25 @@
+{
+  "uid": "golden-uid",
+  "allowed": true,
+  "patchType": "JSONPatch",
+  "patch": [
+    {
+      "op": "add",
+      "path": "/spec/tolerations",
+      "value": [
+        {
+          "effect": "NoSchedule",
+          "key": "arch",
+          "operator": "Equal",
+          "value": "arm64"
+        },
+        {
+          "effect": "NoSchedule",
+          "key": "arch",
+          "operator": "Equal",
+          "value": "amd64"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #15, working through the filed code-hygiene/coverage issues. Four focused commits, each individually verified (`go build`/`vet`/`test`, `gofmt` clean, `golangci-lint` 0 issues).

### Changes

- **Golden-file test for the AdmissionReview response** (`42fa32c`) — pins the webhook's JSON-patch wire shape via a checked-in golden (`admission_golden_test.go` + `testdata/`), regenerated with `go test -run TestProcessAdmissionReview_Golden -update`. Catches serialization/defaulting drift the compiler can't see. The op-sort in the helper keeps each patch op and its canonical sort key together so multi-op patches stay deterministic. _(part 2 of #8)_
- **Remove dead code + de-duplicate namespace-filter logic** (`9cdcf15`) — drops the unused `MultiarchToleration` var, `AddMultiarchTolerationToPod`, and `DoesPodSupportArm64` (#11); extracts the repeated skip-annotation / namespace-filter / namespace-disabled checks from the Pod and DaemonSet branches of `ProcessAdmissionReview` into one `shouldSkipMutation` helper (#12). No behavior change — covered by the existing integration + golden tests.
- **Credential/secret-resolution tests** (`616334e`) — table-driven coverage for the previously untested `decodeDockerAuth`, `hostsFromAuths`, `hostsFromSecret`, and `GetRegistryHosts`, using the client-go fake clientset (`.dockerconfigjson` + legacy `.dockercfg`, base64 auth edge cases, malformed/unsupported secrets, and the service-account fallback). _(#9)_
- **Document the Kubernetes API compatibility guarantee** (`a149814`) — README section on the typed-struct + `go build` compile-time guard against k8s API-shape drift, and the golden test that guards serialization drift. _(part 1 of #8)_

### Verification

`go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt -l .` clean; `golangci-lint run` reports 0 issues.

Closes #8
Closes #9
Closes #11
Closes #12

https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5)_