### PR TITLE
Testable kubeClient, handler/startup tests, fail-fast config, and kind version matrix

### DIFF
--- a/.github/workflows/kind-test.yaml
+++ b/.github/workflows/kind-test.yaml
@@ -4,6 +4,20 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Kubernetes node images to exercise the webhook against. kind runs a
+        # real apiserver, so a green matrix means the webhook works across these
+        # API server versions. These tags must be ones published for the kind
+        # release bundled with helm/kind-action below — bump them deliberately
+        # alongside that action. For full reproducibility, pin each to a digest
+        # (e.g. kindest/node:v1.33.1@sha256:...) and bump the digests on purpose.
+        node_image:
+          - kindest/node:v1.31.6
+          - kindest/node:v1.32.2
+          - kindest/node:v1.33.1
+          - kindest/node:v1.34.0
     steps:
       - uses: actions/checkout@v6
 
@@ -17,6 +31,7 @@ jobs:
         uses: helm/kind-action@v1.14.0
         with:
           cluster_name: kind
+          node_image: ${{ matrix.node_image }}
 
       - name: Build k8smultiarcher image
         env:

--- a/.github/workflows/kind-test.yaml
+++ b/.github/workflows/kind-test.yaml
@@ -9,15 +9,16 @@ jobs:
       matrix:
         # Kubernetes node images to exercise the webhook against. kind runs a
         # real apiserver, so a green matrix means the webhook works across these
-        # API server versions. These tags must be ones published for the kind
-        # release bundled with helm/kind-action below — bump them deliberately
-        # alongside that action. For full reproducibility, pin each to a digest
-        # (e.g. kindest/node:v1.33.1@sha256:...) and bump the digests on purpose.
+        # API server versions. These digests are the prebuilt node images for
+        # kind v0.31.0, which is bundled with helm/kind-action@v1.14.0 below.
+        # Bump them together: when you bump the action, refresh these digests
+        # from the matching kind release notes.
         node_image:
-          - kindest/node:v1.31.6
-          - kindest/node:v1.32.2
-          - kindest/node:v1.33.1
-          - kindest/node:v1.34.0
+          - kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b
+          - kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
+          - kindest/node:v1.33.7@sha256:d26ef333bdb2cbe9862a0f7c3803ecc7b4303d8cea8e814b481b09949d353040
+          - kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
+          - kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
     steps:
       - uses: actions/checkout@v6
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Each mapping in the JSON array supports:
 - `operator` (optional): The toleration operator (default: "Equal")
 - `effect` (optional): The toleration effect (default: "NoSchedule")
 
+> **Validation:** A malformed `PLATFORM_TOLERATIONS` value causes the webhook to exit at startup rather than silently falling back to the simple env vars, so a typo can't quietly change behavior.
+
 #### How It Works
 
 1. When a Pod or DaemonSet is created, k8smultiarcher inspects all container images
@@ -164,6 +166,8 @@ NAMESPACE_SELECTOR='environment=production,team=platform'
 # Set-based selector
 NAMESPACE_SELECTOR='environment in (production,staging)'
 ```
+
+> **Validation:** An invalid `NAMESPACE_SELECTOR` causes the webhook to exit at startup rather than silently disabling filtering.
 
 **`NAMESPACES_TO_IGNORE`** - Skip specific namespaces (comma-separated list)
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -60,8 +61,10 @@ func validateEffect(effect string) corev1.TaintEffect {
 	return eff
 }
 
-// LoadPlatformTolerationConfig loads the configuration from environment variables
-func LoadPlatformTolerationConfig() *PlatformTolerationConfig {
+// LoadPlatformTolerationConfig loads the configuration from environment
+// variables. A malformed PLATFORM_TOLERATIONS value is rejected with an error so
+// a typo fails fast at startup instead of silently falling back to other config.
+func LoadPlatformTolerationConfig() (*PlatformTolerationConfig, error) {
 	config := &PlatformTolerationConfig{
 		Mappings: []PlatformTolerationMapping{},
 	}
@@ -76,26 +79,24 @@ func LoadPlatformTolerationConfig() *PlatformTolerationConfig {
 			Effect   string `json:"effect"`
 		}
 		if err := json.Unmarshal([]byte(jsonConfig), &mappings); err != nil {
-			slog.Error("failed to parse PLATFORM_TOLERATIONS, ignoring JSON config", "error", err)
-			// Fall through to check simple configuration
-		} else {
-			for _, m := range mappings {
-				config.Mappings = append(config.Mappings, PlatformTolerationMapping{
-					Platform: m.Platform,
-					Toleration: corev1.Toleration{
-						Key:      m.Key,
-						Value:    m.Value,
-						Operator: validateOperator(m.Operator),
-						Effect:   validateEffect(m.Effect),
-					},
-				})
-			}
-			// If JSON was successfully parsed, skip simple configuration
-			// to avoid mixing configuration methods
-			if len(config.Mappings) > 0 {
-				slog.Info("loaded platform-toleration mappings from JSON", "count", len(config.Mappings))
-				goto applyDefaults
-			}
+			return nil, fmt.Errorf("invalid PLATFORM_TOLERATIONS JSON: %w", err)
+		}
+		for _, m := range mappings {
+			config.Mappings = append(config.Mappings, PlatformTolerationMapping{
+				Platform: m.Platform,
+				Toleration: corev1.Toleration{
+					Key:      m.Key,
+					Value:    m.Value,
+					Operator: validateOperator(m.Operator),
+					Effect:   validateEffect(m.Effect),
+				},
+			})
+		}
+		// If JSON provided mappings, skip simple configuration to avoid mixing
+		// configuration methods.
+		if len(config.Mappings) > 0 {
+			slog.Info("loaded platform-toleration mappings from JSON", "count", len(config.Mappings))
+			goto applyDefaults
 		}
 	}
 
@@ -145,7 +146,7 @@ applyDefaults:
 		}
 	}
 
-	return config
+	return config, nil
 }
 
 // GetPlatforms returns all configured platforms
@@ -180,8 +181,11 @@ type NamespaceFilterConfig struct {
 	NamespacesToIgnore map[string]bool
 }
 
-// LoadNamespaceFilterConfig loads namespace filtering configuration from environment variables
-func LoadNamespaceFilterConfig() *NamespaceFilterConfig {
+// LoadNamespaceFilterConfig loads namespace filtering configuration from
+// environment variables. An invalid NAMESPACE_SELECTOR is rejected with an error
+// so a bad selector fails fast at startup instead of silently disabling
+// filtering.
+func LoadNamespaceFilterConfig() (*NamespaceFilterConfig, error) {
 	config := &NamespaceFilterConfig{
 		NamespacesToIgnore: make(map[string]bool),
 	}
@@ -190,11 +194,10 @@ func LoadNamespaceFilterConfig() *NamespaceFilterConfig {
 	if selectorStr := os.Getenv("NAMESPACE_SELECTOR"); selectorStr != "" {
 		selector, err := labels.Parse(selectorStr)
 		if err != nil {
-			slog.Error("failed to parse NAMESPACE_SELECTOR, ignoring", "value", selectorStr, "error", err)
-		} else {
-			config.NamespaceSelector = selector
-			slog.Info("loaded namespace selector", "selector", selectorStr)
+			return nil, fmt.Errorf("invalid NAMESPACE_SELECTOR %q: %w", selectorStr, err)
 		}
+		config.NamespaceSelector = selector
+		slog.Info("loaded namespace selector", "selector", selectorStr)
 	}
 
 	// Parse NAMESPACES_TO_IGNORE
@@ -211,7 +214,7 @@ func LoadNamespaceFilterConfig() *NamespaceFilterConfig {
 		}
 	}
 
-	return config
+	return config, nil
 }
 
 // ShouldSkipNamespace checks if a namespace should be skipped based on the filter config

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,10 @@ func TestLoadPlatformTolerationConfig_Default(t *testing.T) {
 	os.Unsetenv("PLATFORM_TOLERATIONS")
 	os.Unsetenv("TOLERATION_KEY")
 
-	config := LoadPlatformTolerationConfig()
+	config, err := LoadPlatformTolerationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
 
 	if len(config.Mappings) != 1 {
 		t.Errorf("Expected 1 default mapping, got %d", len(config.Mappings))
@@ -43,7 +46,10 @@ func TestLoadPlatformTolerationConfig_SimpleEnvVars(t *testing.T) {
 		os.Unsetenv("TOLERATION_PLATFORM")
 	}()
 
-	config := LoadPlatformTolerationConfig()
+	config, err := LoadPlatformTolerationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
 
 	if len(config.Mappings) != 1 {
 		t.Errorf("Expected 1 mapping, got %d", len(config.Mappings))
@@ -82,7 +88,10 @@ func TestLoadPlatformTolerationConfig_JSON(t *testing.T) {
 	os.Setenv("PLATFORM_TOLERATIONS", jsonConfig)
 	defer os.Unsetenv("PLATFORM_TOLERATIONS")
 
-	config := LoadPlatformTolerationConfig()
+	config, err := LoadPlatformTolerationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
 
 	if len(config.Mappings) != 2 {
 		t.Errorf("Expected 2 mappings, got %d", len(config.Mappings))
@@ -110,7 +119,10 @@ func TestLoadPlatformTolerationConfig_JSON_InvalidOperatorAndEffect(t *testing.T
 	os.Setenv("PLATFORM_TOLERATIONS", jsonConfig)
 	defer os.Unsetenv("PLATFORM_TOLERATIONS")
 
-	config := LoadPlatformTolerationConfig()
+	config, err := LoadPlatformTolerationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
 
 	if len(config.Mappings) != 1 {
 		t.Errorf("Expected 1 mapping, got %d", len(config.Mappings))
@@ -123,6 +135,18 @@ func TestLoadPlatformTolerationConfig_JSON_InvalidOperatorAndEffect(t *testing.T
 
 	if config.Mappings[0].Toleration.Effect != corev1.TaintEffectNoSchedule {
 		t.Errorf("Expected effect to default to NoSchedule, got %v", config.Mappings[0].Toleration.Effect)
+	}
+}
+
+func TestLoadPlatformTolerationConfig_MalformedJSON(t *testing.T) {
+	t.Setenv("PLATFORM_TOLERATIONS", `[{"platform": "linux/arm64", "key": }`)
+
+	config, err := LoadPlatformTolerationConfig()
+	if err == nil {
+		t.Fatal("expected an error for malformed PLATFORM_TOLERATIONS, got nil")
+	}
+	if config != nil {
+		t.Errorf("expected nil config on error, got %+v", config)
 	}
 }
 
@@ -260,7 +284,10 @@ func TestLoadNamespaceFilterConfig(t *testing.T) {
 				t.Setenv("NAMESPACES_TO_IGNORE", tt.ignoreEnv)
 			}
 
-			config := LoadNamespaceFilterConfig()
+			config, err := LoadNamespaceFilterConfig()
+			if err != nil {
+				t.Fatalf("unexpected error loading config: %v", err)
+			}
 
 			if tt.expectSelector {
 				if config.NamespaceSelector == nil || config.NamespaceSelector.Empty() {
@@ -276,6 +303,18 @@ func TestLoadNamespaceFilterConfig(t *testing.T) {
 				t.Errorf("Expected %d namespaces to ignore, got %d", tt.expectIgnoreCount, len(config.NamespacesToIgnore))
 			}
 		})
+	}
+}
+
+func TestLoadNamespaceFilterConfig_InvalidSelector(t *testing.T) {
+	t.Setenv("NAMESPACE_SELECTOR", "environment=prod,!@#invalid")
+
+	config, err := LoadNamespaceFilterConfig()
+	if err == nil {
+		t.Fatal("expected an error for an invalid NAMESPACE_SELECTOR, got nil")
+	}
+	if config != nil {
+		t.Errorf("expected nil config on error, got %+v", config)
 	}
 }
 

--- a/k8smultiarcher.go
+++ b/k8smultiarcher.go
@@ -19,8 +19,18 @@ var (
 
 func main() {
 	configureCache()
-	platformConfig = LoadPlatformTolerationConfig()
-	namespaceFilterCfg = LoadNamespaceFilterConfig()
+
+	var err error
+	platformConfig, err = LoadPlatformTolerationConfig()
+	if err != nil {
+		slog.Error("failed to load platform toleration config", "error", err)
+		os.Exit(1)
+	}
+	namespaceFilterCfg, err = LoadNamespaceFilterConfig()
+	if err != nil {
+		slog.Error("failed to load namespace filter config", "error", err)
+		os.Exit(1)
+	}
 
 	startServer(newRouter())
 }

--- a/k8smultiarcher.go
+++ b/k8smultiarcher.go
@@ -22,11 +22,16 @@ func main() {
 	platformConfig = LoadPlatformTolerationConfig()
 	namespaceFilterCfg = LoadNamespaceFilterConfig()
 
+	startServer(newRouter())
+}
+
+// newRouter builds the gin engine with all webhook routes registered.
+func newRouter() *gin.Engine {
 	r := gin.Default()
 	r.POST("/mutate", mutateHandler)
 	r.GET("/healthz", healthzHandler)
 	r.GET("/livez", livezHandler)
-	startServer(r)
+	return r
 }
 
 func mutateHandler(c *gin.Context) {
@@ -59,55 +64,81 @@ func livezHandler(c *gin.Context) {
 }
 
 func configureCache() {
+	c, err := newCacheFromEnv()
+	if err != nil {
+		slog.Error("failed to configure cache", "error", err)
+		os.Exit(1)
+	}
+	cache = c
+}
+
+// newCacheFromEnv builds the cache backend from the CACHE, CACHE_SIZE, and
+// REDIS_ADDR environment variables. It returns an error instead of exiting so
+// the selection and parsing logic can be unit-tested.
+func newCacheFromEnv() (Cache, error) {
 	cacheSizeStr := cmp.Or(os.Getenv("CACHE_SIZE"), strconv.Itoa(cacheSizeDefault))
 	cacheSize, err := strconv.Atoi(cacheSizeStr)
 	if err != nil {
-		slog.Error("invalid cache size", "value", cacheSizeStr, "error", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("invalid cache size %q: %w", cacheSizeStr, err)
 	}
 
 	cacheChoice := cmp.Or(os.Getenv("CACHE"), "inmemory")
 	switch cacheChoice {
 	case "inmemory":
 		slog.Info("using in-memory cache", "size", cacheSize)
-		cache = NewInMemoryCache(cacheSize)
+		return NewInMemoryCache(cacheSize), nil
 	case "redis":
 		redisAddr := cmp.Or(os.Getenv("REDIS_ADDR"), redisAddrDefault)
 		slog.Info("using redis cache", "addr", redisAddr)
-		cache = NewRedisCache(redisAddr)
+		return NewRedisCache(redisAddr), nil
 	default:
-		slog.Error("invalid cache choice", "value", cacheChoice)
-		os.Exit(1)
+		return nil, fmt.Errorf("invalid cache choice %q", cacheChoice)
 	}
 }
 
-func startServer(r *gin.Engine) {
+// serverSettings holds the resolved listen address and TLS configuration.
+type serverSettings struct {
+	addr       string
+	certPath   string
+	keyPath    string
+	tlsEnabled bool
+}
+
+// serverSettingsFromEnv derives the listen address and TLS settings from HOST,
+// PORT, TLS_ENABLED, CERT_PATH, and KEY_PATH, applying the startup defaults.
+// Extracted from startServer so the resolution logic is unit-testable.
+func serverSettingsFromEnv() serverSettings {
 	host := os.Getenv("HOST")
 	port := os.Getenv("PORT")
-	tlsEnabled := os.Getenv("TLS_ENABLED")
+	tlsEnabled := os.Getenv("TLS_ENABLED") == "true"
 	if port == "" {
-		if tlsEnabled == "true" {
+		if tlsEnabled {
 			port = "8443"
 		} else {
 			port = "8080"
 		}
 	}
-	addr := fmt.Sprintf("%s:%s", host, port)
-	if tlsEnabled == "true" {
-		var certPath, keyPath string
-		if certPath = os.Getenv("CERT_PATH"); certPath == "" {
-			certPath = "./certs/tls.crt"
-		}
-		if keyPath = os.Getenv("KEY_PATH"); keyPath == "" {
-			keyPath = "./certs/tls.key"
-		}
-		if err := r.RunTLS(addr, certPath, keyPath); err != nil {
+	s := serverSettings{
+		addr:       fmt.Sprintf("%s:%s", host, port),
+		tlsEnabled: tlsEnabled,
+	}
+	if tlsEnabled {
+		s.certPath = cmp.Or(os.Getenv("CERT_PATH"), "./certs/tls.crt")
+		s.keyPath = cmp.Or(os.Getenv("KEY_PATH"), "./certs/tls.key")
+	}
+	return s
+}
+
+func startServer(r *gin.Engine) {
+	s := serverSettingsFromEnv()
+	if s.tlsEnabled {
+		if err := r.RunTLS(s.addr, s.certPath, s.keyPath); err != nil {
 			slog.Error("failed to start TLS server", "error", err)
 			os.Exit(1)
 		}
 		return
 	}
-	if err := r.Run(addr); err != nil {
+	if err := r.Run(s.addr); err != nil {
 		slog.Error("failed to start server", "error", err)
 		os.Exit(1)
 	}

--- a/k8smultiarcher_test.go
+++ b/k8smultiarcher_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+// newTestRouter returns the production router wired for tests, with gin in test
+// mode and its loggers silenced.
+func newTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	gin.DefaultWriter = io.Discard
+	gin.DefaultErrorWriter = io.Discard
+	return newRouter()
+}
+
+// errReader is an io.Reader whose Read always fails, used to exercise the
+// body-read error path of mutateHandler.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("simulated read failure") }
+
+func TestNewCacheFromEnv(t *testing.T) {
+	t.Run("defaults to in-memory", func(t *testing.T) {
+		t.Setenv("CACHE", "")
+		t.Setenv("CACHE_SIZE", "")
+		c, err := newCacheFromEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := c.(*InMemoryCache); !ok {
+			t.Fatalf("expected *InMemoryCache, got %T", c)
+		}
+	})
+
+	t.Run("in-memory with custom size", func(t *testing.T) {
+		t.Setenv("CACHE", "inmemory")
+		t.Setenv("CACHE_SIZE", "5")
+		c, err := newCacheFromEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := c.(*InMemoryCache); !ok {
+			t.Fatalf("expected *InMemoryCache, got %T", c)
+		}
+	})
+
+	t.Run("redis", func(t *testing.T) {
+		t.Setenv("CACHE", "redis")
+		t.Setenv("REDIS_ADDR", "localhost:6390")
+		c, err := newCacheFromEnv()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := c.(*RedisCache); !ok {
+			t.Fatalf("expected *RedisCache, got %T", c)
+		}
+	})
+
+	t.Run("invalid cache choice", func(t *testing.T) {
+		t.Setenv("CACHE", "bogus")
+		if _, err := newCacheFromEnv(); err == nil {
+			t.Fatal("expected an error for an invalid CACHE value")
+		}
+	})
+
+	t.Run("invalid cache size", func(t *testing.T) {
+		t.Setenv("CACHE_SIZE", "not-a-number")
+		if _, err := newCacheFromEnv(); err == nil {
+			t.Fatal("expected an error for an invalid CACHE_SIZE value")
+		}
+	})
+}
+
+func TestServerSettingsFromEnv(t *testing.T) {
+	t.Run("non-tls defaults", func(t *testing.T) {
+		t.Setenv("HOST", "")
+		t.Setenv("PORT", "")
+		t.Setenv("TLS_ENABLED", "")
+		s := serverSettingsFromEnv()
+		if s.tlsEnabled {
+			t.Errorf("tlsEnabled = true, want false")
+		}
+		if s.addr != ":8080" {
+			t.Errorf("addr = %q, want :8080", s.addr)
+		}
+		if s.certPath != "" || s.keyPath != "" {
+			t.Errorf("expected empty cert/key paths, got cert=%q key=%q", s.certPath, s.keyPath)
+		}
+	})
+
+	t.Run("tls defaults port and cert paths", func(t *testing.T) {
+		t.Setenv("HOST", "")
+		t.Setenv("PORT", "")
+		t.Setenv("TLS_ENABLED", "true")
+		s := serverSettingsFromEnv()
+		if !s.tlsEnabled {
+			t.Errorf("tlsEnabled = false, want true")
+		}
+		if s.addr != ":8443" {
+			t.Errorf("addr = %q, want :8443", s.addr)
+		}
+		if s.certPath != "./certs/tls.crt" || s.keyPath != "./certs/tls.key" {
+			t.Errorf("got cert=%q key=%q, want defaults", s.certPath, s.keyPath)
+		}
+	})
+
+	t.Run("host and port composed", func(t *testing.T) {
+		t.Setenv("HOST", "127.0.0.1")
+		t.Setenv("PORT", "9999")
+		t.Setenv("TLS_ENABLED", "")
+		s := serverSettingsFromEnv()
+		if s.addr != "127.0.0.1:9999" {
+			t.Errorf("addr = %q, want 127.0.0.1:9999", s.addr)
+		}
+	})
+
+	t.Run("tls custom cert and key paths", func(t *testing.T) {
+		t.Setenv("TLS_ENABLED", "true")
+		t.Setenv("CERT_PATH", "/etc/tls/my.crt")
+		t.Setenv("KEY_PATH", "/etc/tls/my.key")
+		s := serverSettingsFromEnv()
+		if s.certPath != "/etc/tls/my.crt" || s.keyPath != "/etc/tls/my.key" {
+			t.Errorf("got cert=%q key=%q, want custom paths", s.certPath, s.keyPath)
+		}
+	})
+}
+
+func TestHealthzAndLivezHandlers(t *testing.T) {
+	router := newTestRouter(t)
+	for _, path := range []string{"/healthz", "/livez"} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", path, w.Code)
+		}
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("%s: decode body: %v", path, err)
+		}
+		if body["status"] != "ok" {
+			t.Errorf("%s: status = %q, want ok", path, body["status"])
+		}
+	}
+}
+
+func TestMutateHandler_Success(t *testing.T) {
+	c := NewInMemoryCache(cacheSizeDefault)
+	c.Set(goldenImage+":linux/arm64", true, 0)
+	c.Set(goldenImage+":linux/amd64", true, 0)
+	cache = c
+	platformConfig = goldenConfig()
+	namespaceFilterCfg = nil
+
+	router := newTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mutate", bytes.NewReader(goldenPodBody(t)))
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var review admissionv1.AdmissionReview
+	if err := json.Unmarshal(w.Body.Bytes(), &review); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if review.Response == nil || !review.Response.Allowed {
+		t.Fatalf("expected an allowed response, got %+v", review.Response)
+	}
+	if len(review.Response.Patch) == 0 {
+		t.Error("expected a non-empty patch for a multi-arch image")
+	}
+}
+
+func TestMutateHandler_ProcessError(t *testing.T) {
+	cache = NewInMemoryCache(cacheSizeDefault)
+	platformConfig = goldenConfig()
+	namespaceFilterCfg = nil
+
+	router := newTestRouter(t)
+	w := httptest.NewRecorder()
+	// An AdmissionReview with no Request fails AdmissionReviewFromRequest.
+	req := httptest.NewRequest(http.MethodPost, "/mutate", strings.NewReader(`{}`))
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMutateHandler_BodyReadError(t *testing.T) {
+	cache = NewInMemoryCache(cacheSizeDefault)
+	platformConfig = goldenConfig()
+	namespaceFilterCfg = nil
+
+	router := newTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mutate", errReader{})
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/registry_auth.go
+++ b/registry_auth.go
@@ -75,7 +75,19 @@ func GetRegistryHosts(ctx context.Context, namespace string, podSpec *corev1.Pod
 	return hosts
 }
 
+// kubeClientFactory resolves the Kubernetes client used to read Secrets,
+// ServiceAccounts, and Namespaces. It is a package var so tests can substitute a
+// fake client without manipulating the sync.Once-guarded singleton below.
+var kubeClientFactory = inClusterKubeClient
+
+// getKubeClient returns the Kubernetes client via the configured factory.
 func getKubeClient() (kubernetes.Interface, error) {
+	return kubeClientFactory()
+}
+
+// inClusterKubeClient lazily builds the in-cluster client once and caches it for
+// the lifetime of the process.
+func inClusterKubeClient() (kubernetes.Interface, error) {
 	kubeClientOnce.Do(func() {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {

--- a/registry_auth_credentials_test.go
+++ b/registry_auth_credentials_test.go
@@ -4,26 +4,34 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"sync"
 	"testing"
 
 	"github.com/regclient/regclient/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 const credTestRegistry = "registry.example.com"
 
-// setKubeClient replaces the package-level kubeClient singleton with the given
-// fake clientset so credential-resolution paths can be exercised without a
-// live cluster.
-func setKubeClient(client *fake.Clientset) {
-	kubeClientOnce = sync.Once{}
-	kubeClientOnce.Do(func() {
-		kubeClient = client
-		kubeClientErr = nil
-	})
+// withKubeClient swaps the package kubeClientFactory to return the given client
+// for the duration of the test, restoring the previous factory on cleanup. This
+// lets tests inject a fake client without touching the kubeClient singleton.
+func withKubeClient(t *testing.T, client kubernetes.Interface) {
+	t.Helper()
+	prev := kubeClientFactory
+	kubeClientFactory = func() (kubernetes.Interface, error) { return client, nil }
+	t.Cleanup(func() { kubeClientFactory = prev })
+}
+
+// withKubeClientErr makes getKubeClient return the given error for the duration
+// of the test.
+func withKubeClientErr(t *testing.T, err error) {
+	t.Helper()
+	prev := kubeClientFactory
+	kubeClientFactory = func() (kubernetes.Interface, error) { return nil, err }
+	t.Cleanup(func() { kubeClientFactory = prev })
 }
 
 func b64(s string) string {
@@ -232,28 +240,28 @@ func TestGetRegistryHosts(t *testing.T) {
 	}
 
 	t.Run("empty namespace returns nil", func(t *testing.T) {
-		setKubeClient(fake.NewSimpleClientset())
+		withKubeClient(t, fake.NewSimpleClientset())
 		if hosts := GetRegistryHosts(context.Background(), "", &corev1.PodSpec{}); hosts != nil {
 			t.Errorf("expected nil, got %#v", hosts)
 		}
 	})
 
 	t.Run("nil pod spec returns nil", func(t *testing.T) {
-		setKubeClient(fake.NewSimpleClientset())
+		withKubeClient(t, fake.NewSimpleClientset())
 		if hosts := GetRegistryHosts(context.Background(), ns, nil); hosts != nil {
 			t.Errorf("expected nil, got %#v", hosts)
 		}
 	})
 
 	t.Run("no image pull secrets returns nil", func(t *testing.T) {
-		setKubeClient(fake.NewSimpleClientset())
+		withKubeClient(t, fake.NewSimpleClientset())
 		if hosts := GetRegistryHosts(context.Background(), ns, &corev1.PodSpec{}); hosts != nil {
 			t.Errorf("expected nil, got %#v", hosts)
 		}
 	})
 
 	t.Run("pod image pull secret is resolved", func(t *testing.T) {
-		setKubeClient(fake.NewSimpleClientset(pullSecret))
+		withKubeClient(t, fake.NewSimpleClientset(pullSecret))
 		podSpec := &corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}}}
 		hosts := GetRegistryHosts(context.Background(), ns, podSpec)
 		if len(hosts) != 1 || hosts[0].User != "alice" || hosts[0].Pass != "s3cret" {
@@ -266,7 +274,7 @@ func TestGetRegistryHosts(t *testing.T) {
 			ObjectMeta:       metav1.ObjectMeta{Name: "default", Namespace: ns},
 			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "regcred"}},
 		}
-		setKubeClient(fake.NewSimpleClientset(pullSecret, sa))
+		withKubeClient(t, fake.NewSimpleClientset(pullSecret, sa))
 		hosts := GetRegistryHosts(context.Background(), ns, &corev1.PodSpec{})
 		if len(hosts) != 1 || hosts[0].User != "alice" {
 			t.Fatalf("unexpected hosts: %#v", hosts)
@@ -274,7 +282,7 @@ func TestGetRegistryHosts(t *testing.T) {
 	})
 
 	t.Run("missing referenced secret yields empty non-nil slice", func(t *testing.T) {
-		setKubeClient(fake.NewSimpleClientset())
+		withKubeClient(t, fake.NewSimpleClientset())
 		podSpec := &corev1.PodSpec{ImagePullSecrets: []corev1.LocalObjectReference{{Name: "nope"}}}
 		hosts := GetRegistryHosts(context.Background(), ns, podSpec)
 		if hosts == nil || len(hosts) != 0 {

--- a/registry_auth_test.go
+++ b/registry_auth_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -103,19 +102,13 @@ func TestIsNamespaceDisabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Reset the kubeClient singleton for each test
-			kubeClientOnce = sync.Once{}
-
-			// Execute the Once.Do to prevent getKubeClient from trying to initialize
-			kubeClientOnce.Do(func() {
-				// Create a fake clientset with the namespace if provided
-				if tt.nsToCreate != nil {
-					kubeClient = fake.NewSimpleClientset(tt.nsToCreate)
-				} else {
-					kubeClient = fake.NewSimpleClientset()
-				}
-				kubeClientErr = nil
-			})
+			// Inject a fake clientset (with the namespace if provided) via the
+			// kubeClientFactory seam; restored automatically after the subtest.
+			if tt.nsToCreate != nil {
+				withKubeClient(t, fake.NewSimpleClientset(tt.nsToCreate))
+			} else {
+				withKubeClient(t, fake.NewSimpleClientset())
+			}
 
 			got := IsNamespaceDisabled(context.Background(), tt.namespace)
 			if got != tt.expected {
@@ -126,14 +119,8 @@ func TestIsNamespaceDisabled(t *testing.T) {
 }
 
 func TestIsNamespaceDisabled_ClientError(t *testing.T) {
-	// Reset the kubeClient singleton
-	kubeClientOnce = sync.Once{}
-
-	// Execute the Once.Do to set up an error scenario
-	kubeClientOnce.Do(func() {
-		kubeClient = nil
-		kubeClientErr = errors.New("simulated client error")
-	})
+	// Simulate the Kubernetes client being unavailable.
+	withKubeClientErr(t, errors.New("simulated client error"))
 
 	// This should return false when client is unavailable
 	got := IsNamespaceDisabled(context.Background(), "test-ns")


### PR DESCRIPTION
Continues the issue-backlog sweep from #16 with four focused, independently-verified commits.

### Changes

- **Make the kubeClient singleton testable** (`a7bb3e1`) — introduces an injectable `kubeClientFactory` (default: lazy in-cluster client), and migrates the namespace + credential tests onto `withKubeClient`/`withKubeClientErr` helpers (restored via `t.Cleanup`) so no test pokes package-level globals anymore. _(#13)_
- **HTTP-handler and server-startup tests** (`b63e261`) — extracts behavior-preserving, unit-testable helpers (`newCacheFromEnv`, `serverSettingsFromEnv`, `newRouter`) from the `os.Exit`-bound startup path, then adds `httptest` coverage for `mutate` (200 / 400 body-read / 500), `healthz`/`livez`, cache selection, and listen-address/TLS resolution. _(#10)_
- **Fail-fast config validation** (`bd5db3b`) — `LoadNamespaceFilterConfig` and `LoadPlatformTolerationConfig` now return an error on an invalid `NAMESPACE_SELECTOR` or malformed `PLATFORM_TOLERATIONS`, and `main()` exits non-zero instead of silently degrading. Tests + README notes included. _(#14)_
- **kind integration tests across k8s versions** (`95108ff`) — adds a `strategy.matrix` over `kindest/node` images (wired into `helm/kind-action`, `fail-fast: false`) so the existing arm64-toleration assertions run once per Kubernetes minor against a real apiserver. _(#7)_

### Verification

`go build ./...`, `go vet ./...`, `go test ./... -count=1` all green; `gofmt -l .` clean; `golangci-lint run` reports 0 issues.

Note: the #7 matrix is exercised only by GitHub Actions (kind needs a real cluster), not by local runs. The `kindest/node` patch tags are a best guess for the kind release bundled in the pinned `helm/kind-action` and may need adjusting to match it (called out in a comment in the workflow).

Closes #7
Closes #10
Closes #13
Closes #14

https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5)_