### PR TITLE
Create a GitHub Release automatically on version tags

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -2,7 +2,8 @@ name: Build and Publish multi-arch image to GHCR
 
 # This workflow builds multi-architecture container images for linux/amd64, linux/arm64, and linux/arm/v7.
 # On push to 'main', it publishes images tagged as 'main' and the commit SHA.
-# On push of version tags (v*), it publishes images tagged as 'latest' and the tag name.
+# On push of version tags (v*), it publishes images tagged as 'latest' and the tag name,
+# and creates a GitHub Release with auto-generated notes.
 # Images are published to ghcr.io under the repository owner's namespace.
 #
 # Future consideration: A separate workflow could rebuild and republish previous release tags
@@ -59,3 +60,20 @@ jobs:
           # Go version is sourced from go.mod so it is defined in a single place.
           build-args: |
             GO_VERSION=${{ steps.goversion.outputs.version }}
+
+  # On version tags, create a GitHub Release with auto-generated notes once the
+  # image has published. Skipped on 'main' pushes via the ref guard below.
+  github-release:
+    name: Create GitHub Release
+    needs: build-and-push
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      # Release creation needs contents: write (overrides the workflow-level
+      # read-only contents permission for this job only).
+      contents: write
+    steps:
+      - name: Create release with generated notes
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/k8smultiarcher.go
+++ b/k8smultiarcher.go
@@ -38,7 +38,9 @@ func main() {
 // newRouter builds the gin engine with all webhook routes registered.
 func newRouter() *gin.Engine {
 	r := gin.Default()
-	r.SetTrustedProxies(nil)
+	if err := r.SetTrustedProxies(nil); err != nil {
+		slog.Error("failed to disable trusted proxies", "error", err)
+	}
 	r.POST("/mutate", mutateHandler)
 	r.GET("/healthz", healthzHandler)
 	r.GET("/livez", livezHandler)


### PR DESCRIPTION
## Problem

Pushing a `v*` tag only builds and pushes the container image — it never creates a GitHub **Release** object. The existing `v0.1.0` / `v0.1.1` Releases were created by hand, which is why `v0.1.2` and `v0.1.3` have no Release entry despite being tagged. (Separately, `v0.1.2` produced no image either, because its tagged commit predates `publish-ghcr.yml`; `v0.1.3` did publish an image.)

## Change

Adds a `github-release` job to `publish-ghcr.yml` that, on `v*` tags only, creates a GitHub Release with auto-generated notes after the image publishes:

```yaml
  github-release:
    name: Create GitHub Release
    needs: build-and-push
    if: startsWith(github.ref, 'refs/tags/v')
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - uses: softprops/action-gh-release@v2
        with:
          generate_release_notes: true
```

- `needs: build-and-push` — the Release is created only after the image is pushed.
- `if: startsWith(github.ref, 'refs/tags/v')` — runs on tag pushes only; skipped on `main` pushes.
- Job-level `permissions: contents: write` — required to create a Release; overrides the workflow-level read-only `contents` for this job only (the image job keeps `packages: write`).

After this merges, `git push origin vX.Y.Z` yields the multi-arch image **and** a GitHub Release in one step.

## Notes / things to confirm in review

- Opened as a **draft** per request.
- It can't be exercised until it's on a branch that receives a `v*` tag push (the workflow doesn't run on `pull_request`), so PR CI (test/lint/kind) covers the rest of the repo but not this job; the YAML/job structure was validated locally.
- `v0.1.3` is already tagged without a Release — this workflow won't backfill it. I can create that Release separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HffCPew1STi6P33Nhbq9U5)_